### PR TITLE
No pam misc on OS X

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 fn main() {
     //TODO: expand this
     println!("cargo:rustc-link-lib=pam");
-    println!("cargo:rustc-link-lib=pam_misc");
+    if cfg!(not(target_os = "macos")) {
+        println!("cargo:rustc-link-lib=pam_misc");
+    }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -76,12 +76,15 @@ extern "C" {
     /* ----------------------- _pam_types.h ------------------------- */
 
     /* ----------------------- pam_misc.h --------------------------- */
+    #[cfg(not(target_os = "macos"))]
     pub fn pam_misc_paste_env(pamh: *mut PamHandle,
                               user_env: *const *const c_char)
                               -> c_int;
 
+    #[cfg(not(target_os = "macos"))]
     pub fn pam_misc_drop_env(env: *mut *mut c_char) -> c_int;
 
+    #[cfg(not(target_os = "macos"))]
     pub fn pam_misc_setenv(pamh: *mut PamHandle,
                            name: *const c_char,
                            value: *const c_char,

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -148,6 +148,7 @@ pub fn getenvlist(handle: &mut PamHandle) -> *const *const c_char {
 
 /* ----------------------- pam_misc.h --------------------------- */
 #[inline]
+#[cfg(not(target_os = "macos"))]
 pub fn misc_paste_env(handle: &mut PamHandle, user_env: &[&str]) -> PamReturnCode {
     // Taken from: https://github.com/rust-lang/rust/issues/9564#issuecomment-95354558
     let user_env: Vec<_> = user_env.iter()
@@ -161,11 +162,13 @@ pub fn misc_paste_env(handle: &mut PamHandle, user_env: &[&str]) -> PamReturnCod
 }
 
 #[inline]
+#[cfg(not(target_os = "macos"))]
 pub fn misc_drop_env(env: &mut *mut c_char) -> PamReturnCode {
     From::from(unsafe { pam_misc_drop_env(env) })
 }
 
 #[inline]
+#[cfg(not(target_os = "macos"))]
 pub fn misc_setenv(handle: &mut PamHandle,
                    name: &str,
                    value: &str,


### PR DESCRIPTION
As discussed in issue #1 this prevents symbols that are not available on OS X from being compiled and prevents `libpam_misc` from being linked there since it is not present.