### PR TITLE
Fix segmentation fault on pam_getenv failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -->
 
 ## [Unreleased]
+- Fixed NULL pointer usage in wrapped::get_env function when pam_getenv fails.
 
 ## [0.5.5] - 2018-03-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -->
 
 ## [Unreleased]
+### Fixed
 - Fixed NULL pointer usage in wrapped::get_env function when pam_getenv fails.
 
 ## [0.5.5] - 2018-03-21

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -132,9 +132,17 @@ pub fn putenv(handle: &mut PamHandle, name_value: &str) -> PamReturnCode {
 
 #[inline]
 pub fn getenv<'a>(handle: &'a mut PamHandle, name: &str) -> Option<&'a str> {
+    use std::ptr;
+	use std::io;
     if let Ok(name) = CString::new(name) {
-        unsafe { CStr::from_ptr(pam_getenv(handle, name.as_ptr())) }.to_str().ok()
-    } else {
+		let env = unsafe{pam_getenv(handle, name.as_ptr())};
+		if env != ptr::null(){
+			unsafe { CStr::from_ptr(env) }.to_str().ok()
+		}
+		else{
+			None
+		}
+	} else {
         None
     }
 }
@@ -208,6 +216,7 @@ pub fn get_user(handle: &PamHandle,
                 user: &mut *const c_char,
                 prompt: *const c_char)
                 -> PamReturnCode {
+				
     From::from(
         unsafe {
             pam_get_user(

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -133,7 +133,6 @@ pub fn putenv(handle: &mut PamHandle, name_value: &str) -> PamReturnCode {
 #[inline]
 pub fn getenv<'a>(handle: &'a mut PamHandle, name: &str) -> Option<&'a str> {
     use std::ptr;
-	use std::io;
     if let Ok(name) = CString::new(name) {
 		let env = unsafe{pam_getenv(handle, name.as_ptr())};
 		if env != ptr::null(){

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -133,7 +133,6 @@ pub fn putenv(handle: &mut PamHandle, name_value: &str) -> PamReturnCode {
 #[inline]
 pub fn getenv<'a>(handle: &'a mut PamHandle, name: &str) -> Option<&'a str> {
     use std::ptr;
-    use std::io;
     if let Ok(name) = CString::new(name) {
         let env = unsafe{pam_getenv(handle, name.as_ptr())};
         if env != ptr::null(){

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -133,15 +133,16 @@ pub fn putenv(handle: &mut PamHandle, name_value: &str) -> PamReturnCode {
 #[inline]
 pub fn getenv<'a>(handle: &'a mut PamHandle, name: &str) -> Option<&'a str> {
     use std::ptr;
+    use std::io;
     if let Ok(name) = CString::new(name) {
-		let env = unsafe{pam_getenv(handle, name.as_ptr())};
-		if env != ptr::null(){
-			unsafe { CStr::from_ptr(env) }.to_str().ok()
-		}
-		else{
-			None
-		}
-	} else {
+        let env = unsafe{pam_getenv(handle, name.as_ptr())};
+        if env != ptr::null(){
+            unsafe { CStr::from_ptr(env) }.to_str().ok()
+        }
+        else{
+            None
+        }
+    } else {
         None
     }
 }
@@ -215,7 +216,7 @@ pub fn get_user(handle: &PamHandle,
                 user: &mut *const c_char,
                 prompt: *const c_char)
                 -> PamReturnCode {
-				
+                
     From::from(
         unsafe {
             pam_get_user(


### PR DESCRIPTION
pam_sys assume that pam_getenv cannot fail, thus never return NULL. 

However when asking for the env vars after the authentication form pam-auth, it is failing and the code is segfaulting.

Changed the code to actually check if the the returned value is the NULL pointer and return Option::None in case.


