### PR TITLE
Wrap pam_get_authtok

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -93,4 +93,12 @@ extern "C" {
                         prompt: *const c_char)
                         -> c_int;
     /* ----------------------- pam_modules.h ------------------------ */
+
+    /* ----------------------- pam_ext.h ---------------------------- */
+    pub fn pam_get_authtok(pamh: *const PamHandle,
+                           item: c_int,
+                           authtok: *mut *const c_char,
+                           prompt: *const c_char)
+                           -> c_int;
+    /* ----------------------- pam_ext.h ---------------------------- */
 }

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -209,3 +209,22 @@ pub fn get_user(handle: &PamHandle,
 }
 
 /* ----------------------- pam_modules.h ------------------------ */
+
+/* ----------------------- pam_ext.h ---------------------------- */
+pub fn get_authtok(handle: &PamHandle,
+                   item: PamItemType,
+                   authtok: &mut *const c_char,
+                   prompt: Option<&CStr>)
+                   -> PamReturnCode {
+    From::from(
+        unsafe {
+            pam_get_authtok(
+                handle,
+                item as c_int,
+                authtok,
+                prompt.map(|str| str.as_ptr()).unwrap_or(std::ptr::null())
+            )
+        }
+    )
+}
+/* ----------------------- pam_ext.h ---------------------------- */

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -115,10 +115,9 @@ pub fn putenv(handle: &mut PamHandle, name_value: &str) -> PamReturnCode {
 
 #[inline]
 pub fn getenv<'a>(handle: &'a mut PamHandle, name: &str) -> Option<&'a str> {
-    use std::ptr;
     if let Ok(name) = CString::new(name) {
         let env = unsafe{pam_getenv(handle, name.as_ptr())};
-        if env != ptr::null(){
+        if !env.is_null() {
             unsafe { CStr::from_ptr(env) }.to_str().ok()
         }
         else{
@@ -196,14 +195,14 @@ pub fn set_data(handle: &mut PamHandle,
 
 pub fn get_user(handle: &PamHandle,
                 user: &mut *const c_char,
-                prompt: *const c_char)
+                prompt: Option<&CStr>)
                 -> PamReturnCode {
     From::from(
         unsafe {
             pam_get_user(
                 handle,
                 user,
-                prompt
+                prompt.map(|str| str.as_ptr()).unwrap_or(std::ptr::null())
             )
         }
     )


### PR DESCRIPTION
This change includes a wrapper for `pam_get_authtok`, which is useful for writing authentication modules.