### PR TITLE
Let default type of macro constants match function signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ azure-devops = { project = "1wilkens/ci", pipeline = "pam-sys" }
 libc = "^0.2.65"
 
 [build-dependencies]
-bindgen = "=0.53.2"
+bindgen = "^0.55"

--- a/build.rs
+++ b/build.rs
@@ -25,6 +25,9 @@ fn main() {
         // Import libc so our signatures are slightly nicer
         .raw_line("use libc::{uid_t, gid_t, group, passwd, spwd};")
         .ctypes_prefix("libc")
+        // Set macro constants to signed int, as all functions that accept
+        // these constants use signed int as the parameter type
+        .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)
         // Blacklist varargs functions and related types for now
         // TODO: find a nice solution for this
         .blacklist_type("va_list")

--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,8 @@ fn main() {
         // Set macro constants to signed int, as all functions that accept
         // these constants use signed int as the parameter type
         .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)
+        // pam_handle is opaque, don't implement Copy
+        .no_copy("pam_handle")
         // Blacklist varargs functions and related types for now
         // TODO: find a nice solution for this
         .blacklist_type("va_list")


### PR DESCRIPTION
The PAM functions all use signed `int` for flag parameters and for return codes, but the associated constants are generated as `u32`. Since version 0.55 `bindgen` allows to set the default signedness of macro constants.

With this the dependency on `bindgen` is upgraded to version 0.55 and constants are by default generated as `i32`, making some typecasts unneccessary.

Also explicitly forbid deriving `Copy` on `pam_handle` as that may cause subtle bugs.
