### PR TITLE
Disable bindgen's default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ azure-devops = { project = "1wilkens/ci", pipeline = "pam-sys" }
 libc = "^0.2.65"
 
 [build-dependencies]
-bindgen = "0.59"
+bindgen = { version = "0.59", default-features = false }


### PR DESCRIPTION
As of the current `1.0.0-alpha4` release, this crate inadvertently includes `clap` as a build-dependency, resulting in the following `cargo tree` output:

```
pam-sys v1.0.0-alpha4
└── libc v0.2.139
[build-dependencies]
└── bindgen v0.59.2
    ├── bitflags v1.3.2
    ├── cexpr v0.6.0
    │   └── nom v7.1.3
    │       ├── memchr v2.5.0
    │       └── minimal-lexical v0.2.1
    ├── clang-sys v1.4.0
    │   ├── glob v0.3.1
    │   ├── libc v0.2.139
    │   └── libloading v0.7.4
    │       └── cfg-if v1.0.0
    │   [build-dependencies]
    │   └── glob v0.3.1
    ├── clap v2.34.0
    │   ├── ansi_term v0.12.1
    │   ├── atty v0.2.14
    │   │   └── libc v0.2.139
    │   ├── bitflags v1.3.2
    │   ├── strsim v0.8.0
    │   ├── textwrap v0.11.0
    │   │   └── unicode-width v0.1.10
    │   ├── unicode-width v0.1.10
    │   └── vec_map v0.8.2
    ├── env_logger v0.9.3
    │   ├── atty v0.2.14 (*)
    │   ├── humantime v2.1.0
    │   ├── log v0.4.17
    │   │   └── cfg-if v1.0.0
    │   ├── regex v1.7.1
    │   │   ├── aho-corasick v0.7.20
    │   │   │   └── memchr v2.5.0
    │   │   ├── memchr v2.5.0
    │   │   └── regex-syntax v0.6.28
    │   └── termcolor v1.2.0
    ├── lazy_static v1.4.0
    ├── lazycell v1.3.0
    ├── log v0.4.17 (*)
    ├── peeking_take_while v0.1.2
    ├── proc-macro2 v1.0.51
    │   └── unicode-ident v1.0.6
    ├── quote v1.0.23
    │   └── proc-macro2 v1.0.51 (*)
    ├── regex v1.7.1 (*)
    ├── rustc-hash v1.1.0
    ├── shlex v1.1.0
    └── which v4.4.0
        ├── either v1.8.1
        └── libc v0.2.139
```

Newer versions of `bindgen` (specifically [0.61.0](https://github.com/rust-lang/rust-bindgen/blob/main/CHANGELOG.md#0610) and later) don't default to including the CLI/`clap`, but I decided to disable the default features while upgrading the version because it removes a few bonus dependencies without breaking my local build:

```
pam-sys v1.0.0-alpha5
└── libc v0.2.139
[build-dependencies]
└── bindgen v0.64.0
    ├── bitflags v1.3.2
    ├── cexpr v0.6.0
    │   └── nom v7.1.3
    │       ├── memchr v2.5.0
    │       └── minimal-lexical v0.2.1
    ├── clang-sys v1.4.0
    │   ├── glob v0.3.1
    │   └── libc v0.2.139
    │   [build-dependencies]
    │   └── glob v0.3.1
    ├── lazy_static v1.4.0
    ├── lazycell v1.3.0
    ├── peeking_take_while v0.1.2
    ├── proc-macro2 v1.0.51
    │   └── unicode-ident v1.0.6
    ├── quote v1.0.23
    │   └── proc-macro2 v1.0.51 (*)
    ├── regex v1.7.1
    │   └── regex-syntax v0.6.28
    ├── rustc-hash v1.1.0
    ├── shlex v1.1.0
    └── syn v1.0.107
        ├── proc-macro2 v1.0.51 (*)
        ├── quote v1.0.23 (*)
        └── unicode-ident v1.0.6
```

I tested the changes with [cargo-semver-checks](https://crates.io/crates/cargo-semver-checks) and this change doesn't seem to cause any breakage with regards to the resulting output.