### PR TITLE
Fixed compilation error on some Linuxes due to bindgen configuration

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,7 @@ fn main() {
         .blocklist_type("va_list")
         .blocklist_type("__va_list")
         .blocklist_type("__builtin_va_list")
+        .blocklist_type("__gnuc_va_list")
         .blocklist_type("__va_list_tag")
         .blocklist_function("pam_v.*")
         .blocklist_function("pam_syslog")


### PR DESCRIPTION
Added __gnuc_va_list to the list of blocked types since this type exists on at least some Linux platforms, and prevents pam-sys from compiling without this exclusion. I have noticed this error on Ubuntu. 